### PR TITLE
Switch vscode-tips link for awesome vscode

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,4 +793,4 @@ task by running the command "Terminate Running Task"
 
 * [vscode official docs](https://code.visualstudio.com/docs)
 * [react sample app](https://github.com/Microsoft/vscode-react-sample)
-* [vscode-tips](https://github.com/tstringer/vscode-tips)
+* [awesome vscode](https://github.com/viatsko/awesome-vscode)


### PR DESCRIPTION
[The repo is no longer maintained](https://github.com/tstringer/vscode-tips/blob/master/README.md) and instead points readers to the `awesome vscode` list. This is a small update to reflect that.