### PR TITLE
Correct default key binding for "Go Forward"

### DIFF
--- a/README.md
+++ b/README.md
@@ -447,7 +447,7 @@ Navigate back.
 
 Navigate Forward.
 
-> Mac: <kbd>ctrl+shift+up</kbd>
+> Mac: <kbd>ctrl+shift+-</kbd>
 
 > Windows / Linux: <kbd>alt+right</kbd>
 


### PR DESCRIPTION
`ctrl+[shift]+up` launches Expose on a Mac so can't really be used (and isn't as it turns out).