### PR TITLE
Fix #51 Font Ligatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ Open `settings.json`
 *Font ligatures*
 
 ```json
+"editor.fontFamily": "Fira Code",
 "editor.fontLigatures": true
 ```
 


### PR DESCRIPTION
- Added setting to set the Font Family to "Fira Code" in order to enable Font Ligatures

## Before: 
![before](https://user-images.githubusercontent.com/1808686/27489202-ace32e44-5807-11e7-8a65-62665a61a8db.png)


## After:

![image](https://user-images.githubusercontent.com/1808686/27488997-f541fb3a-5806-11e7-84d4-8566feb722ae.png)
