### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ Open `settings.json`
 *Auto Save*
 
 ```json
-"files.autoSave": "afterdelay"
+"files.autoSave": "afterDelay"
 ```
 
 You can also toggle Auto Save from the top-level menu with the **File** > **Auto Save**.


### PR DESCRIPTION
Should be `afterDelay`

![screen shot 2017-08-04 at 18 33 15](https://user-images.githubusercontent.com/5300359/28965410-7a7c38b2-7943-11e7-912b-377114801771.png)
