### PR TITLE
Fix kbd tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,7 +384,9 @@ Are you interested in creating your own extension? You can learn how to do this 
 
 ## Integrated terminal
 
-> Windows / Linux / Mac: <kbd>ctrl+`</kbd>
+> Mac / Linux: <kbd>ctrl+`</kbd>
+
+> Windows: <kbd>ctrl+'</kbd>
 
 ![Integrated terminal](/media/integrated_terminal.png)
 


### PR DESCRIPTION
On Windows the apostrophie " ' " is used over the grave accent " \` " to open the terminal. Setting present on default install (VSCode v1.14.2, Windows 10). The " Ctrl+` " does not do anything. Have not tested this in Mac or Linux, as I do not have access to those at present.