### PR TITLE
Fix code folding shortcut

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,7 +612,7 @@ You can group the symbols by kind by adding a colon, `@:`.
 
 ## Code folding
 
-> Mac: <kbd>shift+cmd+\[</kbd> and <kbd>shift+cmd+\]</kbd>
+> Mac: <kbd>alt+cmd+\[</kbd> and <kbd>alt+cmd+\]</kbd>
 
 > Windows / Linux: <kbd>ctrl+shift+\[</kbd> and <kbd>ctrl+shift+\]</kbd>
 


### PR DESCRIPTION
On macOS, it's Alt-Cmd-[ / Alt-Cmd-] instead of Shift.