### PR TITLE
Force formatting of task.json to javascript instead of json

### DIFF
--- a/README.md
+++ b/README.md
@@ -899,7 +899,7 @@ You can set `"debug.inlineValues": true` to see variable values inline in the de
 Select **Tasks** from the top-level menu, run the command **Configure Tasks...**, then select the type of task you'd like to run.
 This will generate a `task.json` file with content like the following. See the Tasks [documentation](https://go.microsoft.com/fwlink/?LinkId=733558) for more details.
 
-```json
+```javascript
 {
     // See http://go.microsoft.com/fwlink/?LinkId=733558
     // for the documentation about the tasks.json format


### PR DESCRIPTION
because comments are invalid in json and don't render correctly in markdown.