### PR TITLE
Removed incorrectly placed full stop

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ See more in the [documentation](https://code.visualstudio.com/docs/languages/jso
 1. In the VS Code [Marketplace](https://marketplace.visualstudio.com/vscode).
 2. Search inside VS Code
 3. View extension recommendations
-4. Community curated extension lists, such as [awesome-vscode](https://github.com/viatsko/awesome-vscode).
+4. Community curated extension lists, such as [awesome-vscode](https://github.com/viatsko/awesome-vscode)
 
 ## Install extensions
 


### PR DESCRIPTION
Just a minor grammatical fix, a full stop should only be used at the end of a complete sentence, and this is not a complete sentence